### PR TITLE
Cast inputs from uint8 to float before computing metrics

### DIFF
--- a/token_bench/metrics_cli.py
+++ b/token_bench/metrics_cli.py
@@ -164,14 +164,8 @@ def main_psnr_ssim() -> None:
         assert (
             input0_file.split("/")[-1] == input1_file.split("/")[-1]
         ), "file names must match"
-        input0 = read_video(input0_file)
-        input1 = read_video(input1_file)
-
-        # cast to float32
-        if input0.dtype != np.float32:
-            input0 = input0.astype(np.float32)
-        if input1.dtype != np.float32:
-            input1 = input1.astype(np.float32)
+        input0 = read_video(input0_file).astype(np.float32)
+        input1 = read_video(input1_file).astype(np.float32)
 
         name = input0_file.split("/")[-1]
         psnr_value = PSNR(input0, input1)

--- a/token_bench/metrics_cli.py
+++ b/token_bench/metrics_cli.py
@@ -167,6 +167,12 @@ def main_psnr_ssim() -> None:
         input0 = read_video(input0_file)
         input1 = read_video(input1_file)
 
+        # cast to float32
+        if input0.dtype != np.float32:
+            input0 = input0.astype(np.float32)
+        if input1.dtype != np.float32:
+            input1 = input1.astype(np.float32)
+
         name = input0_file.split("/")[-1]
         psnr_value = PSNR(input0, input1)
         ssim_value = SSIM(input0, input1)


### PR DESCRIPTION
This PR addresses a bug in the evaluation script for TokenBench. Because videos are read in as uint8 arrays, if the ground truth and reconstructions are subtracted from each other prior to casting to float, the result will potentially under or overflow, changing the resulting value.
For a demonstration of this effect, consider the following simple example:
```
>>> a = np.array(10, dtype=np.uint8)
>>> b = np.array(8, dtype=np.uint8)
>>> b - a
np.uint8(254)
```
This manifests in TokenBench's PSNR calculation here:
```
_FLOAT32_EPS = np.finfo(np.float32).eps
_UINT8_MAX_F = float(np.iinfo(np.uint8).max)
def psnr(pred: _VideoArray, target: _VideoArray):
    mse = ((pred - target) ** 2).mean()  # bug: pred and target are of type np.uint8 here!
    psnr = 20 * np.log10(_UINT8_MAX_F / (np.sqrt(mse) + _FLOAT32_EPS))
    return psnr.item()
```
For example, for the DV 4x8x8 model, the original vs. fixed PSNR results for the DAVIS dataset are as follows.
| Original | Fixed |
|-|-|
|32.98|29.01|

To fix the bug, we cast the input videos to float immediately upon loading. The SSIM and rFVD results do not seem affected by this bug.

We really appreciate the work on TokenBench and believe standardizing the evaluation of these video models is incredibly valuable for the community! We kindly request that the reported values in the benchmark be updated to reflect the fixed results. Thank you for all your hard work! 